### PR TITLE
explicit asignment for auto &ssd = mDesc.samplers[i];

### DIFF
--- a/Engine/source/gfx/gl/gfxGLStateBlock.cpp
+++ b/Engine/source/gfx/gl/gfxGLStateBlock.cpp
@@ -47,7 +47,7 @@ GFXGLStateBlock::GFXGLStateBlock(const GFXStateBlockDesc& desc) :
 	for(int i = 0; i < TEXTURE_STAGE_COUNT; ++i)
 	{
 		GLuint &id = mSamplerObjects[i];
-		auto &ssd = mDesc.samplers[i];
+		GFXSamplerStateDesc &ssd = mDesc.samplers[i];
       Map<GFXSamplerStateDesc, U32>::Iterator itr =  mSamplersMap.find(ssd);
       if(itr == mSamplersMap.end())
       {


### PR DESCRIPTION
Resolves a compiler error with earlier c++ versions.
